### PR TITLE
Add `EFFECT_MUST_USE_SZONE`

### DIFF
--- a/effect.h
+++ b/effect.h
@@ -408,6 +408,7 @@ inline effect_flag operator|(effect_flag flag1, effect_flag flag2)
 #define EFFECT_MAX_MZONE				263
 #define EFFECT_MAX_SZONE				264
 #define EFFECT_MUST_USE_MZONE			265
+#define EFFECT_MUST_USE_SZONE			266
 #define EFFECT_HAND_LIMIT				270
 #define EFFECT_DRAW_COUNT				271
 #define EFFECT_SPIRIT_DONOT_RETURN		280

--- a/effect.h
+++ b/effect.h
@@ -125,6 +125,7 @@ public:
 #define EFFECT_CHANGE_SUMMON_LOCATION_KOISHI				37564161
 #define EFFECT_LINK_SPELL_KOISHI			37564162
 #define EFFECT_SEA_PULSE					37564163
+#define EFFECT_MUST_USE_SZONE			24010
 
 //status
 #define EFFECT_STATUS_AVAILABLE	0x0001
@@ -408,7 +409,6 @@ inline effect_flag operator|(effect_flag flag1, effect_flag flag2)
 #define EFFECT_MAX_MZONE				263
 #define EFFECT_MAX_SZONE				264
 #define EFFECT_MUST_USE_MZONE			265
-#define EFFECT_MUST_USE_SZONE			266
 #define EFFECT_HAND_LIMIT				270
 #define EFFECT_DRAW_COUNT				271
 #define EFFECT_SPIRIT_DONOT_RETURN		280

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -731,6 +731,8 @@ interpreter::interpreter(duel* pd): coroutines(256) {
 	lua_setglobal(lua_state, "EFFECT_LINK_SPELL_KOISHI");
 	lua_pushinteger(lua_state, EFFECT_SEA_PULSE);
 	lua_setglobal(lua_state, "EFFECT_SEA_PULSE");
+	lua_pushinteger(lua_state, EFFECT_MUST_USE_SZONE);
+	lua_setglobal(lua_state, "EFFECT_MUST_USE_SZONE");
 
 	//music hints
 	lua_pushinteger(lua_state, HINT_MUSIC);

--- a/operations.cpp
+++ b/operations.cpp
@@ -4433,6 +4433,7 @@ int32 field::move_to_field(uint16 step, card* target, uint32 enable, uint32 ret,
 					pduel->lua->add_param(lreason, PARAM_TYPE_INT);
 					value = peffect->get_value(target, 3);
 				}
+				value = value >> 8;
 				if (peffect->get_handler_player() != target->current.controler)
 					value = value >> 16;
 				if (value & (0x1 << target->current.sequence)) {


### PR DESCRIPTION
For use with Link Spells:
> [Judgement Arrows](https://yugioh.fandom.com/wiki/Judgement_Arrows): `You can only control . . . "Judgement Arrows". . . in your Spell & Trap Zone a Link Monster points to.`
[Newtrix Nightveil](https://github.com/YGOCC/Moon/commit/8def1708bbf289c266d22c74b380f3507054ed28#diff-e36ce81fd83efc9bb7b027c59661d6f9): `Activate this card so it points to a monster you control.`

Original code by DailyShana, VanillaSalt, & edo9300