### PR TITLE
Add `Duel.SetSummonCancelable`

### DIFF
--- a/libduel.cpp
+++ b/libduel.cpp
@@ -197,7 +197,7 @@ int32 scriptlib::duel_reset_time_limit(lua_State * L) {
 int32 scriptlib::duel_set_summon_cancelable(lua_State *L) {
 	check_param_count(L, 1);
 	duel* pduel = interpreter::get_duel_info(L);
-	duel->game_field->core.summon_cancelable = lua_toboolean(L, 1);
+	pduel->game_field->core.summon_cancelable = lua_toboolean(L, 1);
 	return 0;
 }
 

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -178,7 +178,6 @@ int32 scriptlib::duel_load_script(lua_State *L) {
 	lua_pushboolean(L, pduel->lua->load_script(filename));
 	return 1;
 }
-
 int32 scriptlib::duel_reset_time_limit(lua_State * L) {
 	check_param_count(L, 1);
 	int32 p = lua_tointeger(L, 1);
@@ -193,6 +192,12 @@ int32 scriptlib::duel_reset_time_limit(lua_State * L) {
 	pduel->write_buffer8(MSG_RESET_TIME);
 	pduel->write_buffer8(p);
 	pduel->write_buffer16(time);	
+	return 0;
+}
+int32 scriptlib::duel_set_summon_cancelable(lua_State *L) {
+	check_param_count(L, 1);
+	duel* pduel = interpreter::get_duel_info(L);
+	duel->game_field->core.summon_cancelable = lua_toboolean(L, 1);
 	return 0;
 }
 
@@ -4720,6 +4725,7 @@ static const struct luaL_Reg duellib[] = {
 	{ "LoadScript", scriptlib::duel_load_script },
 	{ "AnnounceCardFilter", scriptlib::duel_announce_card }, // For compat
 	{ "ResetTimeLimit", scriptlib::duel_reset_time_limit },
+	{ "SetSummonCancelable", scriptlib::duel_set_summon_cancelable },
 
 	{ "EnableGlobalFlag", scriptlib::duel_enable_global_flag },
 	{ "GetLP", scriptlib::duel_get_lp },

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -37,6 +37,7 @@ public:
 	static int32 duel_xyz_summon_by_rose(lua_State *L);
 	static int32 duel_load_script(lua_State *L);
 	static int32 duel_reset_time_limit(lua_State *L);
+	static int32 duel_set_summon_cancelable(lua_State *L);
 	//card lib
 	static int32 card_get_code(lua_State *L);
 	static int32 card_get_origin_code(lua_State *L);


### PR DESCRIPTION
The mandatory Special Summoning of a custom-typed monster (e.g. Bigbang, Spatial, Timeleap) by its own procedure can be canceled, even if accidentally, thereby making it optional. This is a bug which I wish to fix by implementing this function, which changes whether one can cancel `Duel.SpecialSummonRule`.